### PR TITLE
Fix Magento 2.3.3 incompatibility

### DIFF
--- a/Model/Transport/Smtp.php
+++ b/Model/Transport/Smtp.php
@@ -17,7 +17,7 @@ use Zend\Mail\Message;
 use Zend\Mail\Transport\SmtpOptions;
 use Ebizmarts\MandrillSmtp\Helper\Data as HelperData;
 use Zend\Mail\Transport\Smtp as SmtpTransport;
-use Magento\Framework\Mail\MessageInterface;
+use Magento\Framework\Mail\EmailMessageInterface;
 
 
 class Smtp extends SmtpTransport
@@ -41,11 +41,11 @@ class Smtp extends SmtpTransport
     }
 
     /**
-     * @param MessageInterface $message
+     * @param EmailMessageInterface $message
      * @throws MailException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function sendMessage(MessageInterface $message)
+    public function sendMessage(EmailMessageInterface $message)
     {
         $options = new SmtpOptions();
         $options->setPort(HelperData::PORT);


### PR DESCRIPTION
Fix #7 by using the correct type hinting. May need additional work to offer backwards compatibility (or just remove the type hint).