### PR TITLE
Fix issue with magento version installation on 2.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     "forum": "http://ebizmarts.com/forums/view/6"
   },
   "require" : {
-    "magento/framework": ">=102.3.3||102.0.*||103.0.*"
+    "magento/framework": ">=102.0.3 <103.1"
   }
 }


### PR DESCRIPTION
Magento framework version is incorrectly defined and this version can't be installed inside magento 2.3.X version because magento/framework:102.3.3 won't exists as you can see in the following screenshot

<img width="1124" alt="Captura de pantalla 2021-04-05 a las 14 30 41" src="https://user-images.githubusercontent.com/31536387/113574865-402f6d00-961d-11eb-8c4b-c045bdb8b1cd.png">

Also check the following error that i get during installation

`    - ebizmarts/magento2-mandrillsmtp 102.3.4 requires magento/framework >=102.3.3||103.0.* -> satisfiable by magento/framework[103.0.0, 103.0.0-p1, 103.0.1, 103.0.1-p1, 103.0.2].
    - Installation request for ebizmarts/magento2-mandrillsmtp 102.3.4 -> satisfiable by ebizmarts/magento2-mandrillsmtp[102.3.4].
`